### PR TITLE
Allow for an optional deffered object to be passed in to directive methods.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 0.4.0
+
+* Allow for an optional deffered object to be passed in to directive methods.
+
 # 0.3.0
 
 * Handle errors on the profile form.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-registration",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "homepage": "https://github.com/incuna/angular-registration",
   "authors": [
     "Perry Roper <perryroper@gmail.com>"

--- a/registration/scripts/directives.js
+++ b/registration/scripts/directives.js
@@ -18,7 +18,7 @@
                 };
                 scope.data = {};
 
-                scope.resetPassword = function () {
+                scope.resetPassword = function (deferred) {
                     if (!form.$pristine) {
                         angular.forEach(scope.fields, function(value, key){
                             value.errors = '';
@@ -38,10 +38,18 @@
                             }];
 
                             form.$setPristine();
+
+                            if (angular.isDefined(deferred)) {
+                                deferred.resolve(response);
+                            }
                         }, function (response) {
                             angular.forEach(response.data, function (error, field) {
                                 scope.fields[field].errors = error[0];
                             });
+
+                            if (angular.isDefined(deferred)) {
+                                deferred.reject(response);
+                            }
                         });
                     }
                 };
@@ -88,7 +96,7 @@
                     }
                 });
 
-                scope.changePassword = function () {
+                scope.changePassword = function (deferred) {
                     if (!form.$pristine) {
                         angular.forEach(scope.fields, function(value, key){
                             value.errors = '';
@@ -123,10 +131,18 @@
                             }
 
                             form.$setPristine();
+
+                            if (angular.isDefined(deferred)) {
+                                deferred.resolve(response);
+                            }
                         }, function (response) {
                             angular.forEach(response.data, function (error, field) {
                                 scope.fields[field].errors = error[0];
                             });
+
+                            if (angular.isDefined(deferred)) {
+                                deferred.reject(response);
+                            }
                         });
                     }
                 };
@@ -151,7 +167,7 @@
                     scope.editUser = angular.copy($rootScope.user);
                 });
 
-                scope.editProfile = function () {
+                scope.editProfile = function (deferred) {
                     if (!form.$pristine) {
                         angular.forEach(scope.fields, function(value, key){
                             value.errors = '';
@@ -167,10 +183,18 @@
                                 }];
 
                                 form.$setPristine();
+
+                                if (angular.isDefined(deferred)) {
+                                    deferred.resolve(response);
+                                }
                             }, function (response) {
                                 angular.forEach(response.data, function (error, field) {
                                     scope.fields[field].errors = error[0];
                                 });
+
+                                if (angular.isDefined(deferred)) {
+                                    deferred.reject(response);
+                                }
                             });
                     }
                 };
@@ -197,7 +221,7 @@
                     scope.fields = response.data.actions.POST;
                 });
 
-                scope.register = function () {
+                scope.register = function (deferred) {
                     if (!form.$pristine) {
                         angular.forEach(scope.fields, function(value, key){
                             value.errors = '';
@@ -223,10 +247,18 @@
 
                                 $location.path(loginPath);
                             }
-                        }, function (response, status) {
+
+                            if (angular.isDefined(deferred)) {
+                                deferred.resolve(response);
+                            }
+                        }, function (response) {
                             angular.forEach(response.data, function (error, field) {
                                 scope.fields[field].errors = error[0];
                             });
+
+                            if (angular.isDefined(deferred)) {
+                                deferred.reject(response);
+                            }
                         });
                     }
                 };


### PR DESCRIPTION
This allows for notifying other scopes of the directive promises being resolved/rejected.

For example:

In your app's scope:

``` js
// Create a deferred object for the registration directive to use.
$scope.registrationDeferred = $q.defer();
// We only care about the outcome of a registration failure.
$scope.registrationDeferred.promise.then(null, function (response) {
    console.log(response);
});
```

In your template:

``` html
<form register-form name="register" ng-submit="register(registrationDeferred)"></form>
```

@incuna/js @maxpeterson
