### PR TITLE
Extend editUser rather than overriding with a copy of the .user

### DIFF
--- a/registration/scripts/directives.js
+++ b/registration/scripts/directives.js
@@ -158,13 +158,15 @@
             link: function (scope, element, attrs) {
                 var form = scope['profile'];
 
+                scope.editUser = {};
+
                 user.options()
                     .then(function (response) {
                         scope.fields = response.data.actions.PUT;
                     });
 
                 $rootScope.$watch('user', function () {
-                    scope.editUser = angular.copy($rootScope.user);
+                    scope.editUser = angular.extend(scope.editUser, $rootScope.user);
                 });
 
                 scope.editProfile = function (deferred) {


### PR DESCRIPTION
If something else modifies a value on the `scope.editUser` object before `$rootScope.user` is
updated with data from the API, the modifications are lost when the the model
does update.

@incuna/js please.
