### PR TITLE
Use gettextCatalog.getString and translate.

### DIFF
--- a/registration/scripts/directives.js
+++ b/registration/scripts/directives.js
@@ -3,7 +3,7 @@
 
     var registration = angular.module('angular-registration');
 
-    registration.directive('passwordResetRequestForm', ['$rootScope', '$http', '$location', 'REGISTRATION', 'PROJECT_SETTINGS', 'gettext', function ($rootScope, $http, $location, REGISTRATION, PROJECT_SETTINGS, gettext) {
+    registration.directive('passwordResetRequestForm', ['$rootScope', '$http', '$location', 'REGISTRATION', 'PROJECT_SETTINGS', 'gettextCatalog', function ($rootScope, $http, $location, REGISTRATION, PROJECT_SETTINGS, gettextCatalog) {
         return {
             restrict: 'A',
             scope: true,
@@ -33,7 +33,7 @@
                             scope.data = {};
                             // TODO: this should come from the API.
                             $rootScope.app.page.messages = [{
-                                msg: gettext('We\'ve sent an email to ' + email + ' that contains a link to reset your password.'),
+                                msg: gettextCatalog.getString('We\'ve sent an email to ' + email + ' that contains a link to reset your password.'),
                                 type: 'success'
                             }];
 
@@ -57,7 +57,7 @@
         };
     }]);
 
-    registration.directive('passwordChangeForm', ['$rootScope', '$http', '$route', '$location', '$filter', 'REGISTRATION', 'PROJECT_SETTINGS', 'gettext', function ($rootScope, $http, $route, $location, $filter, REGISTRATION, PROJECT_SETTINGS, gettext) {
+    registration.directive('passwordChangeForm', ['$rootScope', '$http', '$route', '$location', '$filter', 'REGISTRATION', 'PROJECT_SETTINGS', 'gettextCatalog', function ($rootScope, $http, $route, $location, $filter, REGISTRATION, PROJECT_SETTINGS, gettextCatalog) {
         return {
             restrict: 'A',
             scope: true,
@@ -88,7 +88,7 @@
                             }
 
                             $rootScope.nextRouteMessages = [{
-                                msg: gettext('There was a problem with your verification token. Please try again.')
+                                msg: gettextCatalog.getString('There was a problem with your verification token. Please try again.')
                             }];
 
                             $location.path(resetPath);
@@ -111,7 +111,7 @@
 
                             if (attrs.changeMethod === 'update') {
                                 $rootScope.app.page.messages = [{
-                                    msg: gettext('You have successfully changed your password.'),
+                                    msg: gettextCatalog.getString('You have successfully changed your password.'),
                                     type: 'success'
                                 }];
                             } else {
@@ -123,7 +123,7 @@
                                 }
 
                                 $rootScope.nextRouteMessages = [{
-                                    msg: gettext('You have successfully reset your password. You may now log in below.'),
+                                    msg: gettextCatalog.getString('You have successfully reset your password. You may now log in below.'),
                                     type: 'success'
                                 }];
 
@@ -150,7 +150,7 @@
         };
     }]);
 
-    registration.directive('profileForm', ['$rootScope', '$http', 'user', 'gettext', function ($rootScope, $http, user, gettext) {
+    registration.directive('profileForm', ['$rootScope', '$http', 'user', 'gettextCatalog', function ($rootScope, $http, user, gettextCatalog) {
         return {
             restrict: 'A',
             scope: true,
@@ -180,7 +180,7 @@
                                 $rootScope.user = response.data;
 
                                 $rootScope.app.page.messages = [{
-                                    msg: gettext('You have successfully updated your profile.'),
+                                    msg: gettextCatalog.getString('You have successfully updated your profile.'),
                                     type: 'success'
                                 }];
 

--- a/registration/scripts/routes.js
+++ b/registration/scripts/routes.js
@@ -17,7 +17,7 @@
             .when('/password-reset/', {
                 templateUrl: 'templates/registration/password_reset_request.html',
                 controller: 'PasswordResetRequestCtrl',
-                title: 'Reset your password'
+                title: gettext('Reset your password')
             })
             .when('/password-change/:token*\/', {
                 templateUrl: 'templates/registration/password_change.html',

--- a/registration/scripts/templates.js
+++ b/registration/scripts/templates.js
@@ -2,7 +2,7 @@ angular.module('angular-registration').run(['$templateCache', function($template
   'use strict';
 
   $templateCache.put('templates/registration/base/password_change.html',
-    "<div data-extend-template=templates/unauthenticated_base.html><div data-block=page-inner><h1 data-block=page-body-title>{{ app.page.title }}</h1><form password-change-form=\"\" name=password-change ng-submit=changePassword()></form></div></div>"
+    "<div data-extend-template=templates/unauthenticated_base.html><div data-block=page-inner><h1 data-block=page-body-title>{{ app.page.title|translate }}</h1><form password-change-form=\"\" name=password-change ng-submit=changePassword()></form></div></div>"
   );
 
 
@@ -12,7 +12,7 @@ angular.module('angular-registration').run(['$templateCache', function($template
 
 
   $templateCache.put('templates/registration/base/password_reset_request.html',
-    "<div data-extend-template=templates/unauthenticated_base.html><div data-block=page-inner><h1 data-block=page-body-title>{{ app.page.title }}</h1><form password-reset-request-form=\"\" name=password-reset-request ng-submit=resetPassword()></form></div></div>"
+    "<div data-extend-template=templates/unauthenticated_base.html><div data-block=page-inner><h1 data-block=page-body-title>{{ app.page.title|translate }}</h1><form password-reset-request-form=\"\" name=password-reset-request ng-submit=resetPassword()></form></div></div>"
   );
 
 
@@ -22,7 +22,7 @@ angular.module('angular-registration').run(['$templateCache', function($template
 
 
   $templateCache.put('templates/registration/base/profile.html',
-    "<div data-extend-template=templates/base.html><div data-block=page-breadcrumbs></div><div data-block=page-head-inner>{{ app.page.title }}</div><div data-block=page-body-head></div><div data-block=page-body-content-inner><form profile-form=\"\" name=profile ng-submit=editProfile()></form><form password-change-form=\"\" name=password-change change-method=update ng-submit=changePassword()></form></div></div>"
+    "<div data-extend-template=templates/base.html><div data-block=page-breadcrumbs></div><div data-block=page-head-inner>{{ app.page.title|translate }}</div><div data-block=page-body-head></div><div data-block=page-body-content-inner><form profile-form=\"\" name=profile ng-submit=editProfile()></form><form password-change-form=\"\" name=password-change change-method=update ng-submit=changePassword()></form></div></div>"
   );
 
 
@@ -32,7 +32,7 @@ angular.module('angular-registration').run(['$templateCache', function($template
 
 
   $templateCache.put('templates/registration/base/register.html',
-    "<div data-extend-template=templates/base.html><div data-block=page-breadcrumbs></div><div data-block=page-head-inner>{{ app.page.title }}</div><div data-block=page-body-head></div><div data-block=page-body-content-inner><form register-form=\"\" name=register ng-submit=register()></form></div></div>"
+    "<div data-extend-template=templates/base.html><div data-block=page-breadcrumbs></div><div data-block=page-head-inner>{{ app.page.title|translate }}</div><div data-block=page-body-head></div><div data-block=page-body-content-inner><form register-form=\"\" name=register ng-submit=register()></form></div></div>"
   );
 
 

--- a/registration/templates/registration/base/password_change.html
+++ b/registration/templates/registration/base/password_change.html
@@ -1,6 +1,6 @@
 <div data-extend-template="templates/unauthenticated_base.html">
     <div data-block="page-inner">
-        <h1 data-block="page-body-title">{{ app.page.title }}</h1>
+        <h1 data-block="page-body-title">{{ app.page.title|translate }}</h1>
 
         <form password-change-form name="password-change" ng-submit="changePassword()"></form>
     </div>

--- a/registration/templates/registration/base/password_reset_request.html
+++ b/registration/templates/registration/base/password_reset_request.html
@@ -1,6 +1,6 @@
 <div data-extend-template="templates/unauthenticated_base.html">
     <div data-block="page-inner">
-        <h1 data-block="page-body-title">{{ app.page.title }}</h1>
+        <h1 data-block="page-body-title">{{ app.page.title|translate }}</h1>
 
         <form password-reset-request-form name="password-reset-request" ng-submit="resetPassword()"></form>
     </div>

--- a/registration/templates/registration/base/profile.html
+++ b/registration/templates/registration/base/profile.html
@@ -1,7 +1,7 @@
 <div data-extend-template="templates/base.html">
     <div data-block="page-breadcrumbs"></div>
 
-    <div data-block="page-head-inner">{{ app.page.title }}</div>
+    <div data-block="page-head-inner">{{ app.page.title|translate }}</div>
 
     <div data-block="page-body-head"></div>
 

--- a/registration/templates/registration/base/register.html
+++ b/registration/templates/registration/base/register.html
@@ -1,7 +1,7 @@
 <div data-extend-template="templates/base.html">
     <div data-block="page-breadcrumbs"></div>
 
-    <div data-block="page-head-inner">{{ app.page.title }}</div>
+    <div data-block="page-head-inner">{{ app.page.title|translate }}</div>
 
     <div data-block="page-body-head"></div>
 


### PR DESCRIPTION
Use `gettextCatalog.getString` in directives and controllers and `translate` in the templates (views). `gettext` is only used to mark strings as translatable.
